### PR TITLE
feat(spring-ai): Spring AI 1.1.4 기반 사용량 추출 및 Ledger 연동 엔진 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,6 @@ allprojects {
 
     repositories {
         mavenCentral()
-        maven { url 'https://repo.spring.io/milestone' }
-        maven { url 'https://repo.spring.io/snapshot' }
     }
 }
 
@@ -28,14 +26,13 @@ subprojects {
     dependencyManagement {
         imports {
             mavenBom "org.springframework.boot:spring-boot-dependencies:4.0.5"
-            mavenBom "org.springframework.ai:spring-ai-bom:1.0.0-M1"
+            mavenBom "org.springframework.ai:spring-ai-bom:1.1.4"
         }
     }
 
     dependencies {
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
         testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-        // [모니터링 환경 구축용]
         implementation 'org.springframework.boot:spring-boot-starter-actuator'
         runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
     }

--- a/token-ledger-core/src/main/java/io/tokenledger/core/PricingPlan.java
+++ b/token-ledger-core/src/main/java/io/tokenledger/core/PricingPlan.java
@@ -1,34 +1,88 @@
 package io.tokenledger.core;
 
 import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.Currency;
+import java.util.EnumMap;
+import java.util.Map;
 
 /**
  * 특정 모델의 가격 정책 정보.
- * 1,000(1K) 토큰당 가격을 기준으로 정의합니다.
+ * {@link TokenType} 별로 1,000(1K) 토큰당 가격을 관리합니다.
  *
- * @param modelId              모델 식별자 (예: gpt-4o, claude-3-5-sonnet)
- * @param promptPricePerK      1K 프롬프트 토큰당 가격
- * @param completionPricePerK  1K 응답 토큰당 가격
- * @param currency             통화 (기본값: USD)
+ * @param modelId  모델 식별자 (예: gpt-4o, claude-3-5-sonnet)
+ * @param rates    1K 토큰 타입별 단가 (Map)
+ * @param currency 통화 (기본값: USD)
  */
 public record PricingPlan(
         String modelId,
-        BigDecimal promptPricePerK,
-        BigDecimal completionPricePerK,
+        Map<TokenType, BigDecimal> rates,
         Currency currency
 ) {
     public PricingPlan {
-        if (promptPricePerK.compareTo(BigDecimal.ZERO) < 0 ||
-            completionPricePerK.compareTo(BigDecimal.ZERO) < 0) {
-            throw new IllegalArgumentException("Price cannot be negative");
-        }
+        rates = Collections.unmodifiableMap(new EnumMap<>(rates));
         if (currency == null) {
             currency = Currency.getInstance("USD");
         }
+        // 모든 단가는 0 이상이어야 함
+        rates.values().forEach(v -> {
+            if (v.compareTo(BigDecimal.ZERO) < 0) {
+                throw new IllegalArgumentException("Price cannot be negative");
+            }
+        });
     }
 
+    /**
+     * 기본 입력/출력 단가와 통화를 사용하는 {@link PricingPlan}을 생성합니다.
+     */
+    public PricingPlan(String modelId, BigDecimal promptPricePerK, BigDecimal completionPricePerK, Currency currency) {
+        this(modelId, createRates(promptPricePerK, completionPricePerK), currency);
+    }
+
+    /**
+     * 기본 입력/출력 단가만 사용하는 {@link PricingPlan}을 생성합니다. 기본 통화는 USD입니다.
+     */
     public PricingPlan(String modelId, BigDecimal promptPricePerK, BigDecimal completionPricePerK) {
         this(modelId, promptPricePerK, completionPricePerK, Currency.getInstance("USD"));
+    }
+
+    private static Map<TokenType, BigDecimal> createRates(BigDecimal prompt, BigDecimal completion) {
+        Map<TokenType, BigDecimal> rates = new EnumMap<>(TokenType.class);
+        rates.put(TokenType.PROMPT, prompt);
+        rates.put(TokenType.COMPLETION, completion);
+        return rates;
+    }
+
+    /**
+     * 기본 입력 단가를 반환합니다. (하위 호환성)
+     */
+    public BigDecimal promptPricePerK() {
+        return getRate(TokenType.PROMPT);
+    }
+
+    /**
+     * 기본 출력 단가를 반환합니다. (하위 호환성)
+     */
+    public BigDecimal completionPricePerK() {
+        return getRate(TokenType.COMPLETION);
+    }
+
+    /**
+     * 특정 토큰 타입의 단가를 가져옵니다. 없을 시 계층 구조에 따라 대체값을 반환합니다.
+     * REASONING -> COMPLETION
+     * CACHED_PROMPT -> PROMPT
+     * CACHED_COMPLETION -> COMPLETION
+     */
+    public BigDecimal getRate(TokenType type) {
+        if (rates.containsKey(type)) {
+            return rates.get(type);
+        }
+
+        // Fallback Logic
+        return switch (type) {
+            case REASONING, CACHED_COMPLETION -> rates.getOrDefault(TokenType.COMPLETION, BigDecimal.ZERO);
+            case CACHED_PROMPT -> rates.getOrDefault(TokenType.PROMPT, BigDecimal.ZERO);
+            default -> rates.getOrDefault(type, BigDecimal.ZERO);
+        };
     }
 }

--- a/token-ledger-core/src/main/java/io/tokenledger/core/TokenType.java
+++ b/token-ledger-core/src/main/java/io/tokenledger/core/TokenType.java
@@ -1,0 +1,31 @@
+package io.tokenledger.core;
+
+/**
+ * AI 모델 호출 시 발생하는 토큰의 세부 유형.
+ */
+public enum TokenType {
+    /** 일반 입력 (Prompt) */
+    PROMPT,
+    /** 일반 출력 (Completion) */
+    COMPLETION,
+    /** 추론 (Reasoning) - 주로 출력 계열 */
+    REASONING,
+    /** 캐시된 입력 (Cached Prompt) */
+    CACHED_PROMPT,
+    /** 캐시된 출력 (Cached Completion) */
+    CACHED_COMPLETION;
+
+    /**
+     * 해당 토큰 타입이 입력(Prompt) 계열인지 확인합니다.
+     */
+    public boolean isPrompt() {
+        return this == PROMPT || this == CACHED_PROMPT;
+    }
+
+    /**
+     * 해당 토큰 타입이 출력(Completion) 계열인지 확인합니다.
+     */
+    public boolean isCompletion() {
+        return this == COMPLETION || this == REASONING || this == CACHED_COMPLETION;
+    }
+}

--- a/token-ledger-core/src/main/java/io/tokenledger/core/TokenUsage.java
+++ b/token-ledger-core/src/main/java/io/tokenledger/core/TokenUsage.java
@@ -1,34 +1,77 @@
 package io.tokenledger.core;
 
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.Map;
 
 /**
  * AI 모델 호출 시 발생하는 토큰 사용량 정보.
+ * 세부적인 {@link TokenType} 별로 사용량을 관리합니다.
  *
- * @param promptTokens     프롬프트(입력) 토큰 수
- * @param completionTokens 응답(출력) 토큰 수
- * @param totalTokens      전체 사용 토큰 수
- * @param metadata         추가 메타데이터 (예: cached tokens, reasoning tokens)
+ * @param tokenCounts 토큰 타입별 사용량 (Map)
+ * @param metadata    추가 메타데이터 (예: 모델 정보 등)
  */
 public record TokenUsage(
-        long promptTokens,
-        long completionTokens,
-        long totalTokens,
+        Map<TokenType, Long> tokenCounts,
         Map<String, Object> metadata
 ) {
     public TokenUsage {
+        tokenCounts = Collections.unmodifiableMap(new EnumMap<>(tokenCounts));
         metadata = (metadata != null) ? Collections.unmodifiableMap(metadata) : Map.of();
-        if (promptTokens < 0 || completionTokens < 0 || totalTokens < 0) {
-            throw new IllegalArgumentException("Tokens cannot be negative");
-        }
     }
 
+    /**
+     * 기본 입력/출력 토큰을 사용하는 {@link TokenUsage}를 생성합니다.
+     */
     public static TokenUsage from(long prompt, long completion) {
-        return new TokenUsage(prompt, completion, prompt + completion, Map.of());
+        Map<TokenType, Long> counts = new EnumMap<>(TokenType.class);
+        counts.put(TokenType.PROMPT, prompt);
+        counts.put(TokenType.COMPLETION, completion);
+        return new TokenUsage(counts, Map.of());
     }
 
-    public static TokenUsage from(long prompt, long completion, Map<String, Object> metadata) {
-        return new TokenUsage(prompt, completion, prompt + completion, metadata);
+    /**
+     * 입력/출력/추론 토큰을 포함하는 {@link TokenUsage}를 생성합니다.
+     */
+    public static TokenUsage from(long prompt, long completion, long reasoning) {
+        Map<TokenType, Long> counts = new EnumMap<>(TokenType.class);
+        counts.put(TokenType.PROMPT, prompt);
+        counts.put(TokenType.COMPLETION, completion);
+        counts.put(TokenType.REASONING, reasoning);
+        return new TokenUsage(counts, Map.of());
+    }
+
+    /**
+     * 모든 종류의 입력/출력 토큰 수의 합계를 반환합니다.
+     */
+    public long promptTokens() {
+        return tokenCounts.entrySet().stream()
+                .filter(e -> e.getKey().isPrompt())
+                .mapToLong(Map.Entry::getValue)
+                .sum();
+    }
+
+    /**
+     * 모든 종류의 출력(추론 포함) 토큰 수의 합계를 반환합니다.
+     */
+    public long completionTokens() {
+        return tokenCounts.entrySet().stream()
+                .filter(e -> e.getKey().isCompletion())
+                .mapToLong(Map.Entry::getValue)
+                .sum();
+    }
+
+    /**
+     * 전체 사용 토큰 수의 합계를 반환합니다.
+     */
+    public long totalTokens() {
+        return tokenCounts.values().stream().mapToLong(Long::longValue).sum();
+    }
+
+    /**
+     * 특정 토큰 타입의 사용량을 가져옵니다. 없을 시 0을 반환합니다.
+     */
+    public long getCount(TokenType type) {
+        return tokenCounts.getOrDefault(type, 0L);
     }
 }

--- a/token-ledger-core/src/main/java/io/tokenledger/core/internal/DefaultCostCalculator.java
+++ b/token-ledger-core/src/main/java/io/tokenledger/core/internal/DefaultCostCalculator.java
@@ -3,13 +3,16 @@ package io.tokenledger.core.internal;
 import io.tokenledger.core.Cost;
 import io.tokenledger.core.CostCalculator;
 import io.tokenledger.core.PricingPlan;
+import io.tokenledger.core.TokenType;
 import io.tokenledger.core.TokenUsage;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.Map;
 
 /**
  * 기본 비용 계산기 구현체.
+ * 각 {@link TokenType} 별 단가를 적용하여 정밀하게 계산합니다.
  * 1K 토큰당 가격 정보를 사용하여 소수점 10자리까지 중간 계산 후 6자리로 최종 반올림합니다.
  */
 public class DefaultCostCalculator implements CostCalculator {
@@ -17,14 +20,21 @@ public class DefaultCostCalculator implements CostCalculator {
 
     @Override
     public Cost calculate(TokenUsage usage, PricingPlan plan) {
-        BigDecimal promptCost = plan.promptPricePerK()
-                .multiply(BigDecimal.valueOf(usage.promptTokens()))
-                .divide(THOUSAND, 10, RoundingMode.HALF_UP);
+        BigDecimal totalCostValue = BigDecimal.ZERO;
 
-        BigDecimal completionCost = plan.completionPricePerK()
-                .multiply(BigDecimal.valueOf(usage.completionTokens()))
-                .divide(THOUSAND, 10, RoundingMode.HALF_UP);
+        // 사용된 모든 토큰 타입에 대해 각각의 단가를 적용하여 합산
+        for (Map.Entry<TokenType, Long> entry : usage.tokenCounts().entrySet()) {
+            TokenType type = entry.getKey();
+            Long count = entry.getValue();
 
-        return new Cost(promptCost.add(completionCost), plan.currency());
+            if (count > 0) {
+                BigDecimal rate = plan.getRate(type);
+                BigDecimal typeCost = rate.multiply(BigDecimal.valueOf(count))
+                        .divide(THOUSAND, 10, RoundingMode.HALF_UP);
+                totalCostValue = totalCostValue.add(typeCost);
+            }
+        }
+
+        return new Cost(totalCostValue, plan.currency());
     }
 }

--- a/token-ledger-core/src/test/java/io/tokenledger/core/internal/DefaultCostCalculatorTest.java
+++ b/token-ledger-core/src/test/java/io/tokenledger/core/internal/DefaultCostCalculatorTest.java
@@ -2,12 +2,14 @@ package io.tokenledger.core.internal;
 
 import io.tokenledger.core.Cost;
 import io.tokenledger.core.PricingPlan;
+import io.tokenledger.core.TokenType;
 import io.tokenledger.core.TokenUsage;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
-import java.util.Currency;
+import java.util.EnumMap;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -16,20 +18,60 @@ class DefaultCostCalculatorTest {
     private final DefaultCostCalculator calculator = new DefaultCostCalculator();
 
     @Test
-    @DisplayName("1,000 토큰당 단가를 기준으로 정확한 비용을 계산해야 한다")
-    void shouldCalculateCorrectCost() {
-        // Given: prompt $0.01/1K, completion $0.03/1K
-        PricingPlan plan = new PricingPlan("gpt-4",
-                new BigDecimal("0.01"), new BigDecimal("0.03"), Currency.getInstance("USD"));
-
-        // 500 prompt, 500 completion -> (0.005 + 0.015) = 0.02
-        TokenUsage usage = TokenUsage.from(500, 500);
+    @DisplayName("기본 입력/출력 토큰 비용이 정확하게 계산되어야 한다")
+    void calculateStandardTokens() {
+        // Given: Input $0.01/1k, Output $0.03/1k
+        PricingPlan plan = new PricingPlan("gpt-4o", new BigDecimal("0.01"), new BigDecimal("0.03"));
+        // Usage: Input 1000, Output 2000
+        TokenUsage usage = TokenUsage.from(1000, 2000);
 
         // When
-        Cost result = calculator.calculate(usage, plan);
+        Cost cost = calculator.calculate(usage, plan);
+
+        // Then: (1000 * 0.01 / 1000) + (2000 * 0.03 / 1000) = 0.01 + 0.06 = 0.07
+        assertThat(cost.value()).isEqualByComparingTo("0.070000");
+    }
+
+    @Test
+    @DisplayName("추론 토큰 요율이 다를 때 각각 정밀하게 계산되어야 한다")
+    void calculateReasoningTokensWithDifferentRate() {
+        // Given: Prompt $0.015, Completion $0.060, Reasoning $0.045
+        Map<TokenType, BigDecimal> rates = new EnumMap<>(TokenType.class);
+        rates.put(TokenType.PROMPT, new BigDecimal("0.015"));
+        rates.put(TokenType.COMPLETION, new BigDecimal("0.060"));
+        rates.put(TokenType.REASONING, new BigDecimal("0.045"));
+        PricingPlan plan = new PricingPlan("o1-preview", rates, Cost.DEFAULT_CURRENCY);
+
+        // Usage: Prompt 1000, Completion 500, Reasoning 1500 (Total 3000)
+        Map<TokenType, Long> counts = new EnumMap<>(TokenType.class);
+        counts.put(TokenType.PROMPT, 1000L);
+        counts.put(TokenType.COMPLETION, 500L);
+        counts.put(TokenType.REASONING, 1500L);
+        TokenUsage usage = new TokenUsage(counts, Map.of());
+
+        // When
+        Cost cost = calculator.calculate(usage, plan);
 
         // Then
-        assertThat(result.value()).isEqualByComparingTo("0.020000");
-        assertThat(result.currency().getCurrencyCode()).isEqualTo("USD");
+        // 1000 * 0.015 / 1000 = 0.015
+        //  500 * 0.060 / 1000 = 0.030
+        // 1500 * 0.045 / 1000 = 0.0675
+        // Total = 0.015 + 0.030 + 0.0675 = 0.1125
+        assertThat(cost.value()).isEqualByComparingTo("0.112500");
+    }
+
+    @Test
+    @DisplayName("추론 토큰 요율이 명시되지 않으면 일반 출력 요율을 따라야 한다")
+    void calculateReasoningTokensWithFallback() {
+        // Given: Prompt $0.01, Completion $0.03 (Reasoning 없음)
+        PricingPlan plan = new PricingPlan("gpt-4o", new BigDecimal("0.01"), new BigDecimal("0.03"));
+        // Usage: Prompt 1000, Completion 0, Reasoning 1000
+        TokenUsage usage = TokenUsage.from(1000, 0, 1000);
+
+        // When
+        Cost cost = calculator.calculate(usage, plan);
+
+        // Then: 1000 * 0.01 / 1000 + 1000 * 0.03 / 1000 = 0.04
+        assertThat(cost.value()).isEqualByComparingTo("0.040000");
     }
 }

--- a/token-ledger-spring-ai/build.gradle
+++ b/token-ledger-spring-ai/build.gradle
@@ -1,8 +1,9 @@
 dependencies {
     api project(':token-ledger-core')
 
-    // Spring AI의 핵심 인터페이스 (BOM에 의해 버전 결정됨)
-    implementation 'org.springframework.ai:spring-ai-core'
+    // 1.1.x 버전부터 spring-ai-core가 분리됨
+    implementation 'org.springframework.ai:spring-ai-model'
+    implementation 'org.springframework.ai:spring-ai-client-chat'
     
     // Reactor (스트리밍 처리를 위한 Flux 등)
     implementation 'io.projectreactor:reactor-core'

--- a/token-ledger-spring-ai/src/main/java/io/tokenledger/springai/LedgerAdvisor.java
+++ b/token-ledger-spring-ai/src/main/java/io/tokenledger/springai/LedgerAdvisor.java
@@ -1,0 +1,31 @@
+package io.tokenledger.springai;
+
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.client.ChatClientResponse;
+import org.springframework.ai.chat.client.advisor.api.AdvisorChain;
+import org.springframework.ai.chat.client.advisor.api.BaseAdvisor;
+
+/**
+ * ChatClient 호출 시 토큰 사용량을 가로채서 기록하는 어드바이저 인터페이스.
+ * Spring AI의 {@link BaseAdvisor}를 상속하여 AI 호출 전후 처리 로직을 표준 방식으로 정의합니다.
+ */
+public interface LedgerAdvisor extends BaseAdvisor {
+
+    @Override
+    default ChatClientRequest before(ChatClientRequest chatClientRequest, AdvisorChain advisorChain) {
+        return chatClientRequest;
+    }
+
+    @Override
+    ChatClientResponse after(ChatClientResponse chatClientResponse, AdvisorChain advisorChain);
+
+    @Override
+    default String getName() {
+        return "LedgerAdvisor";
+    }
+
+    @Override
+    default int getOrder() {
+        return 0;
+    }
+}

--- a/token-ledger-spring-ai/src/main/java/io/tokenledger/springai/UsageExtractor.java
+++ b/token-ledger-spring-ai/src/main/java/io/tokenledger/springai/UsageExtractor.java
@@ -1,0 +1,11 @@
+package io.tokenledger.springai;
+
+import io.tokenledger.core.TokenUsage;
+import org.springframework.ai.chat.client.ChatClientResponse;
+
+/**
+ * AI 응답({@link ChatClientResponse})에서 토큰 사용량 정보를 추출하는 인터페이스.
+ */
+public interface UsageExtractor {
+    TokenUsage extract(ChatClientResponse response);
+}

--- a/token-ledger-spring-ai/src/main/java/io/tokenledger/springai/internal/DefaultLedgerAdvisor.java
+++ b/token-ledger-spring-ai/src/main/java/io/tokenledger/springai/internal/DefaultLedgerAdvisor.java
@@ -1,0 +1,64 @@
+package io.tokenledger.springai.internal;
+
+import io.tokenledger.core.LedgerManager;
+import io.tokenledger.core.TokenUsage;
+import io.tokenledger.springai.LedgerAdvisor;
+import io.tokenledger.springai.UsageExtractor;
+import org.springframework.ai.chat.client.ChatClientResponse;
+import org.springframework.ai.chat.client.advisor.api.AdvisorChain;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 기본 {@link LedgerAdvisor} 구현체.
+ * {@link UsageExtractor}를 사용하여 토큰 사용량을 추출하고,
+ * 그 결과를 {@link LedgerManager}에 기록하는 핵심 비즈니스 로직을 수행합니다.
+ */
+public class DefaultLedgerAdvisor implements LedgerAdvisor {
+
+    private final LedgerManager ledgerManager;
+    private final UsageExtractor usageExtractor;
+
+    public DefaultLedgerAdvisor(LedgerManager ledgerManager, UsageExtractor usageExtractor) {
+        this.ledgerManager = ledgerManager;
+        this.usageExtractor = usageExtractor;
+    }
+
+    @Override
+    public ChatClientResponse after(ChatClientResponse response, AdvisorChain chain) {
+        TokenUsage usage = usageExtractor.extract(response);
+        
+        String modelId = extractModelId(response);
+        Map<String, String> tags = extractTags(response);
+
+        ledgerManager.record(modelId, usage, tags);
+
+        return response;
+    }
+
+    private String extractModelId(ChatClientResponse response) {
+        if (response.chatResponse() != null && response.chatResponse().getMetadata() != null) {
+            String model = response.chatResponse().getMetadata().getModel();
+            if (model != null && !model.isBlank()) {
+                return model;
+            }
+        }
+        return "unknown-model";
+    }
+
+    private Map<String, String> extractTags(ChatClientResponse response) {
+        Map<String, String> tags = new HashMap<>();
+        
+        Map<String, Object> context = response.context();
+        if (context != null) {
+            context.forEach((k, v) -> {
+                if (v instanceof String s) {
+                    tags.put(k, s);
+                }
+            });
+        }
+
+        return tags;
+    }
+}

--- a/token-ledger-spring-ai/src/main/java/io/tokenledger/springai/internal/DefaultUsageExtractor.java
+++ b/token-ledger-spring-ai/src/main/java/io/tokenledger/springai/internal/DefaultUsageExtractor.java
@@ -1,0 +1,68 @@
+package io.tokenledger.springai.internal;
+
+import io.tokenledger.core.TokenType;
+import io.tokenledger.core.TokenUsage;
+import io.tokenledger.springai.UsageExtractor;
+import org.springframework.ai.chat.client.ChatClientResponse;
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.metadata.Usage;
+import org.springframework.ai.chat.model.ChatResponse;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * 기본 {@link UsageExtractor} 구현체.
+ * Spring AI의 {@link Usage} 정보를 {@link TokenUsage}로 변환하며,
+ * 메타데이터에 포함된 추론(Reasoning) 토큰 등을 식별하여 세분화된 사용량을 추출합니다.
+ */
+public class DefaultUsageExtractor implements UsageExtractor {
+
+    @Override
+    public TokenUsage extract(ChatClientResponse response) {
+        ChatResponse chatResponse = response.chatResponse();
+        if (chatResponse == null || chatResponse.getMetadata().getUsage() == null) {
+            return TokenUsage.from(0, 0);
+        }
+
+        Usage usage = chatResponse.getMetadata().getUsage();
+        Map<TokenType, Long> counts = new EnumMap<>(TokenType.class);
+
+        long prompt = (usage.getPromptTokens() != null) ? usage.getPromptTokens() : 0L;
+        long completion = (usage.getCompletionTokens() != null) ? usage.getCompletionTokens() : 0L;
+        
+        counts.put(TokenType.PROMPT, prompt);
+        counts.put(TokenType.COMPLETION, completion);
+
+        ChatResponseMetadata metadata = chatResponse.getMetadata();
+        
+        Long reasoning = extractReasoningTokens(metadata);
+        if (reasoning > 0) {
+            counts.put(TokenType.REASONING, reasoning);
+        }
+
+        // ChatResponseMetadata에서 Map 정보를 복사하여 TokenUsage 생성
+        Map<String, Object> metadataMap = new java.util.HashMap<>();
+        metadata.keySet().forEach(key -> metadataMap.put(key, metadata.get(key)));
+
+        return new TokenUsage(counts, metadataMap);
+    }
+
+    private Long extractReasoningTokens(ChatResponseMetadata metadata) {
+        // metadata는 직접 Map이 아닐 수 있으므로 get 메서드로 개별 접근
+        Object details = metadata.get("completion_tokens_details");
+        if (details instanceof Map<?, ?> detailsMap) {
+            Object reasoning = detailsMap.get("reasoning_tokens");
+            if (reasoning instanceof Number num) {
+                return num.longValue();
+            }
+        }
+        
+        Object directReasoning = metadata.get("reasoning_tokens");
+        if (directReasoning instanceof Number num) {
+            return num.longValue();
+        }
+
+        return 0L;
+    }
+}

--- a/token-ledger-spring-ai/src/test/java/io/tokenledger/springai/internal/DefaultLedgerAdvisorTest.java
+++ b/token-ledger-spring-ai/src/test/java/io/tokenledger/springai/internal/DefaultLedgerAdvisorTest.java
@@ -1,0 +1,58 @@
+package io.tokenledger.springai.internal;
+
+import io.tokenledger.core.LedgerManager;
+import io.tokenledger.core.TokenUsage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.client.ChatClientResponse;
+import org.springframework.ai.chat.client.advisor.api.AdvisorChain;
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+class DefaultLedgerAdvisorTest {
+
+    @Test
+    @DisplayName("AI 응답 후 사용량, 모델ID, 태그가 올바르게 LedgerManager에 기록되어야 한다")
+    void recordAfterAIResponse() {
+        LedgerManager ledgerManager = mock(LedgerManager.class);
+        DefaultUsageExtractor extractor = mock(DefaultUsageExtractor.class);
+        TokenUsage mockUsage = TokenUsage.from(100, 200);
+        when(extractor.extract(any())).thenReturn(mockUsage);
+
+        DefaultLedgerAdvisor advisor = new DefaultLedgerAdvisor(ledgerManager, extractor);
+
+        ChatResponseMetadata metadata = ChatResponseMetadata.builder()
+                .model("gpt-4o")
+                .build();
+        ChatResponse chatResponse = new ChatResponse(List.of(new Generation(new org.springframework.ai.chat.messages.AssistantMessage("test"))), metadata);
+        Map<String, Object> context = Map.of("user_id", "user-123", "tenant_id", "tenant-abc");
+        ChatClientResponse response = new ChatClientResponse(chatResponse, context);
+
+        advisor.after(response, mock(AdvisorChain.class));
+
+        verify(ledgerManager, times(1)).record(
+                eq("gpt-4o"),
+                eq(mockUsage),
+                argThat(tags -> tags.get("user_id").equals("user-123") && 
+                               tags.get("tenant_id").equals("tenant-abc"))
+        );
+    }
+
+    @Test
+    @DisplayName("Advisor 이름과 순서가 기본값으로 설정되어야 한다")
+    void checkAdvisorMetadata() {
+        DefaultLedgerAdvisor advisor = new DefaultLedgerAdvisor(mock(LedgerManager.class), mock(DefaultUsageExtractor.class));
+
+        assertThat(advisor.getName()).isEqualTo("LedgerAdvisor");
+        assertThat(advisor.getOrder()).isEqualTo(0);
+    }
+}

--- a/token-ledger-spring-ai/src/test/java/io/tokenledger/springai/internal/DefaultUsageExtractorTest.java
+++ b/token-ledger-spring-ai/src/test/java/io/tokenledger/springai/internal/DefaultUsageExtractorTest.java
@@ -1,0 +1,65 @@
+package io.tokenledger.springai.internal;
+
+import io.tokenledger.core.TokenType;
+import io.tokenledger.core.TokenUsage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.client.ChatClientResponse;
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.metadata.Usage;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DefaultUsageExtractorTest {
+
+    private final DefaultUsageExtractor extractor = new DefaultUsageExtractor();
+
+    @Test
+    @DisplayName("표준 사용량 정보가 포함된 응답에서 토큰 정보를 추출해야 한다")
+    void extractStandardUsage() {
+        Usage usage = mock(Usage.class);
+        when(usage.getPromptTokens()).thenReturn(100);
+        when(usage.getCompletionTokens()).thenReturn(200);
+
+        ChatResponseMetadata metadata = ChatResponseMetadata.builder()
+                .usage(usage)
+                .build();
+
+        ChatResponse chatResponse = new ChatResponse(List.of(new Generation(new org.springframework.ai.chat.messages.AssistantMessage("test"))), metadata);
+        ChatClientResponse response = new ChatClientResponse(chatResponse, Map.of());
+
+        TokenUsage result = extractor.extract(response);
+
+        assertThat(result.getCount(TokenType.PROMPT)).isEqualTo(100L);
+        assertThat(result.getCount(TokenType.COMPLETION)).isEqualTo(200L);
+    }
+
+    @Test
+    @DisplayName("메타데이터에 추론 토큰이 포함된 경우 이를 별도로 식별해야 한다")
+    void extractReasoningUsage() {
+        Usage usage = mock(Usage.class);
+        when(usage.getPromptTokens()).thenReturn(100);
+        when(usage.getCompletionTokens()).thenReturn(200);
+
+        ChatResponseMetadata metadata = ChatResponseMetadata.builder()
+                .usage(usage)
+                .keyValue("completion_tokens_details", Map.of("reasoning_tokens", 150))
+                .build();
+
+        ChatResponse chatResponse = new ChatResponse(List.of(new Generation(new org.springframework.ai.chat.messages.AssistantMessage("test"))), metadata);
+        ChatClientResponse response = new ChatClientResponse(chatResponse, Map.of());
+
+        TokenUsage result = extractor.extract(response);
+
+        assertThat(result.getCount(TokenType.PROMPT)).isEqualTo(100L);
+        assertThat(result.getCount(TokenType.COMPLETION)).isEqualTo(200L);
+        assertThat(result.getCount(TokenType.REASONING)).isEqualTo(150L);
+    }
+}


### PR DESCRIPTION
### 변경 사항 개요
- **Spring AI 1.1.4 정식 릴리스 지원**: BOM 버전을 최신 1.1.4로 업데이트하고, 파편화된 모듈(, )에 맞게 의존성을 재편했습니다.
- **표준 LedgerAdvisor 구현**: 최신 를 상속받아 동기()와 스트리밍() 호출을 모두 지원하는 인터셉터를 완성했습니다.
- **정밀한 토큰 추출 로직**: 를 통해 OpenAI의  등 특수 토큰을 메타데이터에서 식별하여  모델에 정확히 매핑합니다.
- **Ledger 연동 강화**: 가 응답 메타데이터의 와 컨텍스트 태그들을 추출하여 에 기록하도록 엔진을 완성했습니다.

### 다음 작업 예정
-  모듈을 통한 자동 빈 등록 기능 구현
-  연동을 통한 가시화 레이어 구축