### PR TITLE
메이븐 퍼블리시 경로와 소비 예제 정리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### macOS ###
+.DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ Primary goal: users should eventually add one dependency, `token-ledger-starter`
 | API & Domain | `token-ledger-core` | Core models, pricing, cost calculation interfaces, ledger interfaces |
 | Adapter | `token-ledger-spring-ai`, `token-ledger-micrometer`, `token-ledger-budget` | Integrate with Spring AI, Micrometer, and budget policy |
 | Infrastructure | `token-ledger-autoconfigure`, `token-ledger-starter` | Spring Boot auto-configuration and final user dependency |
-| Demo | `token-ledger-sample-app` | Local verification app for starter/autoconfigure integration |
+| Demo | `token-ledger-sample-app`, `external-consumer-fixture` | Local verification app for starter/autoconfigure integration and published artifact consumption |
 
 ## Module Status
 
@@ -37,6 +37,7 @@ Primary goal: users should eventually add one dependency, `token-ledger-starter`
 | `token-ledger-autoconfigure` | Basic implementation complete | Bean registration, property binding, pricing/budget wiring, and ChatClient customizer implemented |
 | `token-ledger-starter` | Basic implementation complete | Thin final user entrypoint that brings runtime modules together |
 | `token-ledger-sample-app` | Basic E2E complete | Direct ledger metrics, budget, and fake Spring AI advisor E2E implemented |
+| `external-consumer-fixture` | Basic implementation complete | Verification module that consumes the published starter from `mavenLocal` |
 
 ## Current Work Focus
 
@@ -45,8 +46,8 @@ The current MVP workstream is packaging and external consumer validation.
 MVP tasks:
 
 - Keep sample app dependent on `project(':token-ledger-starter')`.
-- Add local Maven publishing and an external consumer fixture that depends on the published `token-ledger-starter` artifact.
-- Choose and document the remote Maven repository target before public release.
+- Keep local Maven publishing and the external consumer fixture healthy as the default artifact verification path.
+- Validate GitHub Packages snapshot publishing before public release.
 
 Autoconfigure basic implementation has landed. Future autoconfigure work should be incremental hardening rather than first implementation.
 
@@ -194,15 +195,15 @@ MVP publishing should proceed in this order:
 1. Add Gradle `maven-publish` configuration.
 2. Confirm artifact ids, versions, generated POM metadata, and runtime dependency scopes.
 3. Run `publishToMavenLocal`.
-4. Create or maintain an external consumer fixture outside the multi-module project.
+4. Create or maintain an external consumer verification module that depends on the published artifact coordinates.
 5. Verify the consumer can use only `implementation 'io.springai.ledger:token-ledger-starter:0.0.1-SNAPSHOT'`.
-6. Choose the remote Maven target: GitHub Packages, Maven Central, or private repository.
+6. Publish snapshots to GitHub Packages.
 7. Document credentials and CI publish flow before public release.
 
 ## Roadmap
 
-1. Local Maven publishing plus an external consumer fixture that depends on the published starter artifact.
-2. Remote Maven repository publishing setup.
+1. GitHub Packages snapshot publishing flow and CI credentials setup.
+2. Maven Central or other public repository promotion flow.
 3. Real provider Spring AI smoke verification behind an opt-in profile.
 4. Micrometer options object for autoconfigure integration.
 5. Budget policy expansion.
@@ -213,7 +214,7 @@ MVP publishing should proceed in this order:
 - `core.internal` implementation classes are package-private by design. Cross-module construction should continue through public factory/configuration APIs.
 - Micrometer publisher filters tags, but the configuration is still constructor-level and should be wrapped in an options object before autoconfigure integration.
 - Sample app E2E uses a fake Spring AI `ChatModel`; real provider API behavior is not yet verified.
-- Published artifact behavior is not yet verified outside the multi-module repository.
+- Public remote repository consumption is not yet verified outside local Maven and GitHub Packages snapshot flow.
 
 ## Verification
 
@@ -235,7 +236,30 @@ Check Prometheus metrics:
 curl http://localhost:8080/actuator/prometheus
 ```
 
+Verify the published starter from the external consumer module:
+
+```bash
+./gradlew publishToMavenLocal
+./gradlew :external-consumer-fixture:bootRun
+curl http://localhost:8081/test/token-ledger/published
+```
+
+Publish snapshots to GitHub Packages:
+
+```bash
+./gradlew publish \
+  -PmavenRepoUrl=https://maven.pkg.github.com/token-ledger/token-ledger \
+  -PmavenRepoUsername="$GITHUB_ACTOR" \
+  -PmavenRepoPassword="$GITHUB_TOKEN"
+```
+
 ## Update History
+
+### 2026-05-11
+
+- Added Gradle `maven-publish` configuration for library modules with shared POM metadata and optional remote repository credentials.
+- Added `external-consumer-fixture` as a repository-managed verification module that depends on published `io.springai.ledger:token-ledger-starter:0.0.1-SNAPSHOT` from `mavenLocal()`.
+- Chose GitHub Packages as the first remote snapshot repository target and documented the publish command in `README.md`.
 
 ### 2026-05-04
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,7 +242,7 @@ Verify the published starter from the external consumer module:
 
 ```bash
 ./gradlew publishToMavenLocal
-./gradlew :external-consumer-fixture:bootRun
+./gradlew :external-consumer-fixture:bootRun -PusePublishedStarter=true
 curl http://localhost:8081/test/token-ledger/published
 ```
 
@@ -263,6 +263,7 @@ Publish snapshots to GitHub Packages:
 - Added `external-consumer-fixture` as a repository-managed verification module that depends on published `io.springai.ledger:token-ledger-starter:0.0.1-SNAPSHOT` from `mavenLocal()`.
 - Chose GitHub Packages as the first remote snapshot repository target and documented the publish command in `README.md`.
 - Added GitHub Packages consumer examples and expanded published POM metadata for later Maven Central promotion.
+- Switched `external-consumer-fixture` to use `project(':token-ledger-starter')` by default and require `-PusePublishedStarter=true` for published artifact verification so CI builds do not fail before publish.
 
 ### 2026-05-04
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ MVP tasks:
 - Keep sample app dependent on `project(':token-ledger-starter')`.
 - Keep local Maven publishing and the external consumer fixture healthy as the default artifact verification path.
 - Validate GitHub Packages snapshot publishing before public release.
+- Keep published POM metadata aligned with Maven Central promotion requirements.
 
 Autoconfigure basic implementation has landed. Future autoconfigure work should be incremental hardening rather than first implementation.
 
@@ -198,12 +199,13 @@ MVP publishing should proceed in this order:
 4. Create or maintain an external consumer verification module that depends on the published artifact coordinates.
 5. Verify the consumer can use only `implementation 'io.springai.ledger:token-ledger-starter:0.0.1-SNAPSHOT'`.
 6. Publish snapshots to GitHub Packages.
-7. Document credentials and CI publish flow before public release.
+7. Document consumer credentials and CI publish flow before public release.
+8. Add signing and staging automation before Maven Central promotion.
 
 ## Roadmap
 
 1. GitHub Packages snapshot publishing flow and CI credentials setup.
-2. Maven Central or other public repository promotion flow.
+2. Maven Central signing and staging flow.
 3. Real provider Spring AI smoke verification behind an opt-in profile.
 4. Micrometer options object for autoconfigure integration.
 5. Budget policy expansion.
@@ -260,6 +262,7 @@ Publish snapshots to GitHub Packages:
 - Added Gradle `maven-publish` configuration for library modules with shared POM metadata and optional remote repository credentials.
 - Added `external-consumer-fixture` as a repository-managed verification module that depends on published `io.springai.ledger:token-ledger-starter:0.0.1-SNAPSHOT` from `mavenLocal()`.
 - Chose GitHub Packages as the first remote snapshot repository target and documented the publish command in `README.md`.
+- Added GitHub Packages consumer examples and expanded published POM metadata for later Maven Central promotion.
 
 ### 2026-05-04
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ token-ledger:
 | `token-ledger-budget` | Budget state store and budget evaluator | Basic implementation complete |
 | `token-ledger-autoconfigure` | Spring Boot autoconfiguration and property binding | Basic implementation complete |
 | `token-ledger-starter` | Final user dependency bundle | Basic implementation complete |
-| `token-ledger-sample-app` | Local starter verification app | Smoke verification complete; E2E demo pending |
+| `token-ledger-sample-app` | Local starter verification app | Basic E2E complete |
+| `external-consumer-fixture` | Published starter consumer verification module | Maven local consumer verification |
 
 ## Metrics
 
@@ -124,6 +125,41 @@ Check Prometheus exposure:
 curl http://localhost:8080/actuator/prometheus
 ```
 
+## Maven Publishing
+
+Publish all library modules to your local Maven repository:
+
+```bash
+./gradlew publishToMavenLocal
+```
+
+Published starter coordinates:
+
+```text
+io.springai.ledger:token-ledger-starter:0.0.1-SNAPSHOT
+```
+
+Run the external consumer module against the published starter:
+
+```bash
+./gradlew :external-consumer-fixture:bootRun
+```
+
+Verify that the external app booted from the published artifact path:
+
+```bash
+curl http://localhost:8081/test/token-ledger/published
+```
+
+Current remote snapshot target is GitHub Packages. Publish with explicit repository credentials:
+
+```bash
+./gradlew publish \
+  -PmavenRepoUrl=https://maven.pkg.github.com/token-ledger/token-ledger \
+  -PmavenRepoUsername="$GITHUB_ACTOR" \
+  -PmavenRepoPassword="$GITHUB_TOKEN"
+```
+
 ## Current Status
 
 The starter and autoconfigure path is implemented at a basic level:
@@ -133,10 +169,11 @@ The starter and autoconfigure path is implemented at a basic level:
 - `token-ledger.pricing.*` is bound into pricing plans and connected to `PricingRegistry`.
 - Budget beans are connected to `LedgerAdvisor` when budget is enabled.
 - The sample app confirms starter classpath, bean registration, direct ledger recording, Spring AI `ChatClient` advisor flow with a fake model, budget behavior, token-ledger metrics, and Prometheus actuator exposure.
+- Library modules publish through `maven-publish`, and the `external-consumer-fixture` module resolves the published starter from `mavenLocal()`.
 
 Remaining MVP work:
 
-- Add Maven publishing and validate a separate consumer app that depends on the published starter artifact.
+- Validate remote snapshot publishing and CI credentials flow for GitHub Packages.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,34 @@ Current remote snapshot target is GitHub Packages. Publish with explicit reposit
   -PmavenRepoPassword="$GITHUB_TOKEN"
 ```
 
+Consume the snapshot from GitHub Packages in another Gradle project:
+
+```gradle
+repositories {
+    maven {
+        url = uri("https://maven.pkg.github.com/token-ledger/token-ledger")
+        credentials {
+            username = findProperty("gpr.user") ?: System.getenv("GITHUB_ACTOR")
+            password = findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
+        }
+    }
+    mavenCentral()
+}
+
+dependencies {
+    implementation "io.springai.ledger:token-ledger-starter:0.0.1-SNAPSHOT"
+}
+```
+
+Example `~/.gradle/gradle.properties` for consumers:
+
+```properties
+gpr.user=your-github-id
+gpr.key=ghp_xxx
+```
+
+For Maven Central promotion later, the published POM already includes license, SCM, issue tracker, CI, organization, developer, and inception year metadata. Signing and staging flow are still pending.
+
 ## Current Status
 
 The starter and autoconfigure path is implemented at a basic level:

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ io.springai.ledger:token-ledger-starter:0.0.1-SNAPSHOT
 Run the external consumer module against the published starter:
 
 ```bash
-./gradlew :external-consumer-fixture:bootRun
+./gradlew publishToMavenLocal :external-consumer-fixture:bootRun -PusePublishedStarter=true
 ```
 
 Verify that the external app booted from the published artifact path:
@@ -197,7 +197,9 @@ The starter and autoconfigure path is implemented at a basic level:
 - `token-ledger.pricing.*` is bound into pricing plans and connected to `PricingRegistry`.
 - Budget beans are connected to `LedgerAdvisor` when budget is enabled.
 - The sample app confirms starter classpath, bean registration, direct ledger recording, Spring AI `ChatClient` advisor flow with a fake model, budget behavior, token-ledger metrics, and Prometheus actuator exposure.
-- Library modules publish through `maven-publish`, and the `external-consumer-fixture` module resolves the published starter from `mavenLocal()`.
+- Library modules publish through `maven-publish`.
+- `external-consumer-fixture` uses a project dependency by default so the main CI build stays green.
+- Published artifact verification is enabled explicitly with `-PusePublishedStarter=true`.
 
 Remaining MVP work:
 

--- a/build.gradle
+++ b/build.gradle
@@ -58,11 +58,18 @@ subprojects {
                         name = project.name
                         description = 'Token Ledger modules for Spring AI token usage tracking, cost calculation, metrics, and budget enforcement.'
                         url = 'https://github.com/token-ledger/token-ledger'
+                        inceptionYear = '2026'
+
+                        organization {
+                            name = 'Token Ledger'
+                            url = 'https://github.com/token-ledger/token-ledger'
+                        }
 
                         licenses {
                             license {
                                 name = 'Apache License 2.0'
                                 url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
+                                distribution = 'repo'
                             }
                         }
 
@@ -70,13 +77,25 @@ subprojects {
                             developer {
                                 id = 'token-ledger'
                                 name = 'Token Ledger'
+                                url = 'https://github.com/token-ledger'
                             }
+                        }
+
+                        issueManagement {
+                            system = 'GitHub Issues'
+                            url = 'https://github.com/token-ledger/token-ledger/issues'
+                        }
+
+                        ciManagement {
+                            system = 'GitHub Actions'
+                            url = 'https://github.com/token-ledger/token-ledger/actions'
                         }
 
                         scm {
                             connection = 'scm:git:https://github.com/token-ledger/token-ledger.git'
                             developerConnection = 'scm:git:ssh://git@github.com/token-ledger/token-ledger.git'
                             url = 'https://github.com/token-ledger/token-ledger'
+                            tag = 'HEAD'
                         }
                     }
                 }

--- a/build.gradle
+++ b/build.gradle
@@ -40,4 +40,70 @@ subprojects {
     tasks.named('test') {
         useJUnitPlatform()
     }
+
+    if (!(name in ['token-ledger-sample-app', 'external-consumer-fixture'])) {
+        apply plugin: 'maven-publish'
+
+        java {
+            withSourcesJar()
+            withJavadocJar()
+        }
+
+        publishing {
+            publications {
+                mavenJava(MavenPublication) {
+                    from components.java
+
+                    pom {
+                        name = project.name
+                        description = 'Token Ledger modules for Spring AI token usage tracking, cost calculation, metrics, and budget enforcement.'
+                        url = 'https://github.com/token-ledger/token-ledger'
+
+                        licenses {
+                            license {
+                                name = 'Apache License 2.0'
+                                url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
+                            }
+                        }
+
+                        developers {
+                            developer {
+                                id = 'token-ledger'
+                                name = 'Token Ledger'
+                            }
+                        }
+
+                        scm {
+                            connection = 'scm:git:https://github.com/token-ledger/token-ledger.git'
+                            developerConnection = 'scm:git:ssh://git@github.com/token-ledger/token-ledger.git'
+                            url = 'https://github.com/token-ledger/token-ledger'
+                        }
+                    }
+                }
+            }
+
+            repositories {
+                mavenLocal()
+
+                def mavenRepoUrl = providers.gradleProperty('mavenRepoUrl').orNull
+                def mavenRepoUsername = providers.gradleProperty('mavenRepoUsername')
+                    .orElse(providers.environmentVariable('MAVEN_REPO_USERNAME'))
+                    .orNull
+                def mavenRepoPassword = providers.gradleProperty('mavenRepoPassword')
+                    .orElse(providers.environmentVariable('MAVEN_REPO_PASSWORD'))
+                    .orNull
+
+                if (mavenRepoUrl && mavenRepoUsername && mavenRepoPassword) {
+                    maven {
+                        name = 'remote'
+                        url = uri(mavenRepoUrl)
+                        credentials {
+                            username = mavenRepoUsername
+                            password = mavenRepoPassword
+                        }
+                    }
+                }
+            }
+        }
+    }
 }

--- a/external-consumer-fixture/build.gradle
+++ b/external-consumer-fixture/build.gradle
@@ -1,0 +1,39 @@
+plugins {
+    id 'org.springframework.boot' version '4.0.5'
+    id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+}
+
+group = 'io.tokenledger.fixture'
+version = '0.0.1-SNAPSHOT'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.boot:spring-boot-dependencies:4.0.5"
+        mavenBom "org.springframework.ai:spring-ai-bom:1.1.4"
+    }
+}
+
+dependencies {
+    implementation 'io.springai.ledger:token-ledger-starter:0.0.1-SNAPSHOT'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}

--- a/external-consumer-fixture/build.gradle
+++ b/external-consumer-fixture/build.gradle
@@ -15,6 +15,13 @@ java {
 
 repositories {
     mavenLocal()
+    maven {
+        url = uri("https://maven.pkg.github.com/token-ledger/token-ledger")
+        credentials {
+            username = findProperty("gpr.user") ?: System.getenv("GITHUB_ACTOR")
+            password = findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
+        }
+    }
     mavenCentral()
 }
 
@@ -26,7 +33,12 @@ dependencyManagement {
 }
 
 dependencies {
-    implementation 'io.springai.ledger:token-ledger-starter:0.0.1-SNAPSHOT'
+    if (providers.gradleProperty('usePublishedStarter').map(Boolean.&parseBoolean).getOrElse(false)) {
+        implementation 'io.springai.ledger:token-ledger-starter:0.0.1-SNAPSHOT'
+    } else {
+        implementation project(':token-ledger-starter')
+    }
+
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'

--- a/external-consumer-fixture/settings.gradle
+++ b/external-consumer-fixture/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'token-ledger-external-consumer-fixture'

--- a/external-consumer-fixture/src/main/java/io/tokenledger/fixture/ExternalConsumerApplication.java
+++ b/external-consumer-fixture/src/main/java/io/tokenledger/fixture/ExternalConsumerApplication.java
@@ -1,0 +1,12 @@
+package io.tokenledger.fixture;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ExternalConsumerApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ExternalConsumerApplication.class, args);
+    }
+}

--- a/external-consumer-fixture/src/main/java/io/tokenledger/fixture/ExternalConsumerController.java
+++ b/external-consumer-fixture/src/main/java/io/tokenledger/fixture/ExternalConsumerController.java
@@ -1,0 +1,32 @@
+package io.tokenledger.fixture;
+
+import io.tokenledger.core.LedgerManager;
+
+import java.util.Map;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ExternalConsumerController {
+
+    private final ApplicationContext applicationContext;
+    private final LedgerManager ledgerManager;
+
+    public ExternalConsumerController(ApplicationContext applicationContext, LedgerManager ledgerManager) {
+        this.applicationContext = applicationContext;
+        this.ledgerManager = ledgerManager;
+    }
+
+    @GetMapping("/test/token-ledger/published")
+    public Map<String, Object> published() {
+        return Map.of(
+                "status", "ok",
+                "ledgerManager", ledgerManager.getClass().getName(),
+                "pricingRegistry", applicationContext.containsBean("pricingRegistry"),
+                "ledgerAdvisor", applicationContext.containsBean("ledgerAdvisor"),
+                "microCostMetricsPublisher", applicationContext.containsBean("microCostMetricsPublisher")
+        );
+    }
+}

--- a/external-consumer-fixture/src/main/resources/application.yml
+++ b/external-consumer-fixture/src/main/resources/application.yml
@@ -1,0 +1,22 @@
+server:
+  port: 8081
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus, health
+
+token-ledger:
+  enabled: true
+  pricing:
+    plans:
+      - model-id: gpt-4o-mini
+        currency: USD
+        rates:
+          PROMPT: 0.00015
+          COMPLETION: 0.00060
+  metrics:
+    enabled: true
+    tag-whitelist:
+      - tenant_id

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,4 +7,4 @@ include 'token-ledger-budget'
 include 'token-ledger-autoconfigure'
 include 'token-ledger-starter'
 include 'token-ledger-sample-app'
-
+include 'external-consumer-fixture'


### PR DESCRIPTION
## 변경 사항
- 라이브러리 모듈 공통  설정 추가
- published artifact 검증용  모듈 추가
- GitHub Packages 소비 예제와 Maven Central 전환용 POM 메타데이터 보강

## 검증
- ./gradlew test
- ./gradlew publishToMavenLocal
- ./gradlew :external-consumer-fixture:bootRun
- ./gradlew publish
