### PR TITLE
메이븐 그룹 ID를 cloud.token-ledger로 전환

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ Expected final user setup:
 
 ```gradle
 dependencies {
-    implementation 'io.springai.ledger:token-ledger-starter'
+    implementation 'cloud.token-ledger:token-ledger-starter'
 }
 ```
 
@@ -197,7 +197,7 @@ MVP publishing should proceed in this order:
 2. Confirm artifact ids, versions, generated POM metadata, and runtime dependency scopes.
 3. Run `publishToMavenLocal`.
 4. Create or maintain an external consumer verification module that depends on the published artifact coordinates.
-5. Verify the consumer can use only `implementation 'io.springai.ledger:token-ledger-starter:0.0.1-SNAPSHOT'`.
+5. Verify the consumer can use only `implementation 'cloud.token-ledger:token-ledger-starter:0.0.1-SNAPSHOT'`.
 6. Publish snapshots to GitHub Packages.
 7. Document consumer credentials and CI publish flow before public release.
 8. Add signing and staging automation before Maven Central promotion.
@@ -260,7 +260,7 @@ Publish snapshots to GitHub Packages:
 ### 2026-05-11
 
 - Added Gradle `maven-publish` configuration for library modules with shared POM metadata and optional remote repository credentials.
-- Added `external-consumer-fixture` as a repository-managed verification module that depends on published `io.springai.ledger:token-ledger-starter:0.0.1-SNAPSHOT` from `mavenLocal()`.
+- Added `external-consumer-fixture` as a repository-managed verification module that depends on published `cloud.token-ledger:token-ledger-starter:0.0.1-SNAPSHOT` from `mavenLocal()`.
 - Chose GitHub Packages as the first remote snapshot repository target and documented the publish command in `README.md`.
 - Added GitHub Packages consumer examples and expanded published POM metadata for later Maven Central promotion.
 - Switched `external-consumer-fixture` to use `project(':token-ledger-starter')` by default and require `-PusePublishedStarter=true` for published artifact verification so CI builds do not fail before publish.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The intended user experience is one dependency plus `token-ledger.*` configurati
 
 ```gradle
 dependencies {
-    implementation 'io.springai.ledger:token-ledger-starter'
+    implementation 'cloud.token-ledger:token-ledger-starter'
 }
 ```
 
@@ -136,7 +136,7 @@ Publish all library modules to your local Maven repository:
 Published starter coordinates:
 
 ```text
-io.springai.ledger:token-ledger-starter:0.0.1-SNAPSHOT
+cloud.token-ledger:token-ledger-starter:0.0.1-SNAPSHOT
 ```
 
 Run the external consumer module against the published starter:
@@ -175,7 +175,7 @@ repositories {
 }
 
 dependencies {
-    implementation "io.springai.ledger:token-ledger-starter:0.0.1-SNAPSHOT"
+    implementation "cloud.token-ledger:token-ledger-starter:0.0.1-SNAPSHOT"
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 allprojects {
-    group = 'io.springai.ledger'
+    group = 'cloud.token-ledger'
     version = '0.0.1-SNAPSHOT'
 
     repositories {

--- a/external-consumer-fixture/build.gradle
+++ b/external-consumer-fixture/build.gradle
@@ -34,7 +34,7 @@ dependencyManagement {
 
 dependencies {
     if (providers.gradleProperty('usePublishedStarter').map(Boolean.&parseBoolean).getOrElse(false)) {
-        implementation 'io.springai.ledger:token-ledger-starter:0.0.1-SNAPSHOT'
+        implementation 'cloud.token-ledger:token-ledger-starter:0.0.1-SNAPSHOT'
     } else {
         implementation project(':token-ledger-starter')
     }

--- a/token-ledger-sample-app/build.gradle
+++ b/token-ledger-sample-app/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'java'
 }
 
-group = 'io.springai.ledger'
+group = 'cloud.token-ledger'
 version = '0.0.1-SNAPSHOT'
 
 repositories {


### PR DESCRIPTION
## 변경 사항
- Maven groupId를 cloud.token-ledger로 전환
- sample app, external consumer fixture, 문서 좌표를 새 groupId로 정리
- published artifact 검증 경로를 cloud.token-ledger 기준으로 검증

## 검증
- ./gradlew build
- ./gradlew publishToMavenLocal
- ./gradlew :external-consumer-fixture:classes -PusePublishedStarter=true
