### PR TITLE
Central Portal 릴리스 배포 설정 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,8 @@ MVP tasks:
 - Keep local Maven publishing and the external consumer fixture healthy as the default artifact verification path.
 - Validate GitHub Packages snapshot publishing before public release.
 - Keep published POM metadata aligned with Maven Central promotion requirements.
+- Keep Gradle signing and release property wiring ready for Central release work.
+- Keep JReleaser Central Portal staging and deploy wiring aligned with the verified `cloud.token-ledger` namespace.
 
 Autoconfigure basic implementation has landed. Future autoconfigure work should be incremental hardening rather than first implementation.
 
@@ -205,7 +207,7 @@ MVP publishing should proceed in this order:
 ## Roadmap
 
 1. GitHub Packages snapshot publishing flow and CI credentials setup.
-2. Maven Central signing and staging flow.
+2. Maven Central staging and release execution flow hardening.
 3. Real provider Spring AI smoke verification behind an opt-in profile.
 4. Micrometer options object for autoconfigure integration.
 5. Budget policy expansion.
@@ -255,6 +257,19 @@ Publish snapshots to GitHub Packages:
   -PmavenRepoPassword="$GITHUB_TOKEN"
 ```
 
+Prepare a signed release build locally:
+
+```bash
+./gradlew publishToMavenLocal -PprojectVersion=0.0.1
+```
+
+Stage and deploy a Central release:
+
+```bash
+./gradlew publishAllPublicationsToStagingRepository -PprojectVersion=0.0.1
+./gradlew jreleaserDeploy -PprojectVersion=0.0.1
+```
+
 ## Update History
 
 ### 2026-05-11
@@ -264,6 +279,9 @@ Publish snapshots to GitHub Packages:
 - Chose GitHub Packages as the first remote snapshot repository target and documented the publish command in `README.md`.
 - Added GitHub Packages consumer examples and expanded published POM metadata for later Maven Central promotion.
 - Switched `external-consumer-fixture` to use `project(':token-ledger-starter')` by default and require `-PusePublishedStarter=true` for published artifact verification so CI builds do not fail before publish.
+- Added Gradle `signing` integration and `projectVersion` override support so release builds can be produced with local GPG material before Central Portal upload wiring is finalized.
+- Prefer `signingKeyFile` over inline `signingKey` for local release signing because multiline armored keys are less error-prone when loaded from a file.
+- Added JReleaser Gradle integration targeting the Central Publisher Portal with `build/staging-deploy` staging repositories and `cloud.token-ledger` namespace wiring.
 
 ### 2026-05-04
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ Publish all library modules to your local Maven repository:
 ./gradlew publishToMavenLocal
 ```
 
+Prepare a release build with signing enabled:
+
+```bash
+./gradlew publishToMavenLocal -PprojectVersion=0.0.1
+```
+
 Published starter coordinates:
 
 ```text
@@ -187,6 +193,36 @@ gpr.key=ghp_xxx
 ```
 
 For Maven Central promotion later, the published POM already includes license, SCM, issue tracker, CI, organization, developer, and inception year metadata. Signing and staging flow are still pending.
+
+Example `~/.gradle/gradle.properties` for release signing and Central Portal credentials:
+
+```properties
+signingPublicKeyFile=/absolute/path/to/public.asc
+signingKeyFile=/absolute/path/to/secring.asc
+signingPassword=your-gpg-passphrase
+centralUsername=your-central-portal-token-username
+centralPassword=your-central-portal-token-password
+```
+
+Create the signing key file once:
+
+```bash
+mkdir -p ~/.gradle
+gpg --armor --export 1198AD22D5C72EAB > ~/.gradle/token-ledger-public.asc
+gpg --armor --export-secret-keys 1198AD22D5C72EAB > ~/.gradle/token-ledger-signing.asc
+chmod 600 ~/.gradle/token-ledger-public.asc
+chmod 600 ~/.gradle/token-ledger-signing.asc
+```
+
+Release-to-Central flow:
+
+```bash
+./gradlew publishAllPublicationsToStagingRepository -PprojectVersion=0.0.1
+./gradlew jreleaserConfig -PprojectVersion=0.0.1
+./gradlew jreleaserDeploy -PprojectVersion=0.0.1
+```
+
+The repository now supports release-friendly version overrides with `-PprojectVersion=0.0.1`, signs published artifacts automatically when the signing key file properties are present, stages release artifacts into `build/staging-deploy`, and wires JReleaser to the Central Publisher Portal.
 
 ## Current Status
 

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,16 @@ jreleaser {
                     active = 'RELEASE'
                     url = 'https://central.sonatype.com/api/v1/publisher'
                     namespace = 'cloud.token-ledger'
-                    stagingRepository('build/staging-deploy')
+                    [
+                        'token-ledger-core',
+                        'token-ledger-spring-ai',
+                        'token-ledger-micrometer',
+                        'token-ledger-budget',
+                        'token-ledger-autoconfigure',
+                        'token-ledger-starter'
+                    ].each { moduleName ->
+                        stagingRepository("${moduleName}/build/staging-deploy")
+                    }
 
                     if (centralUsername) {
                         username = centralUsername

--- a/build.gradle
+++ b/build.gradle
@@ -2,14 +2,101 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '4.0.5' apply false
     id 'io.spring.dependency-management' version '1.1.7' apply false
+    id 'org.jreleaser' version '1.24.0'
 }
 
 allprojects {
     group = 'cloud.token-ledger'
-    version = '0.0.1-SNAPSHOT'
+    version = providers.gradleProperty('projectVersion').orElse('0.0.1-SNAPSHOT').get()
 
     repositories {
         mavenCentral()
+    }
+}
+
+jreleaser {
+    def signingPublicKeyFile = providers.gradleProperty('signingPublicKeyFile')
+        .orElse(providers.environmentVariable('SIGNING_PUBLIC_KEY_FILE'))
+        .orNull
+    def signingSecretKeyFile = providers.gradleProperty('signingKeyFile')
+        .orElse(providers.environmentVariable('SIGNING_KEY_FILE'))
+        .orNull
+    def signingPassphrase = providers.gradleProperty('signingPassword')
+        .orElse(providers.environmentVariable('SIGNING_PASSWORD'))
+        .orNull
+    def centralUsername = providers.gradleProperty('centralUsername')
+        .orElse(providers.environmentVariable('CENTRAL_USERNAME'))
+        .orNull
+    def centralPassword = providers.gradleProperty('centralPassword')
+        .orElse(providers.environmentVariable('CENTRAL_PASSWORD'))
+        .orNull
+
+    gitRootSearch = true
+
+    project {
+        copyright = '2026 Token Ledger'
+        authors = ['Token Ledger']
+        description = 'Token Ledger modules for Spring AI token usage tracking, cost calculation, metrics, and budget enforcement.'
+        inceptionYear = '2026'
+        links {
+            homepage = 'https://github.com/token-ledger/token-ledger'
+        }
+    }
+
+    def githubToken = providers.gradleProperty('githubToken')
+        .orElse(providers.environmentVariable('GITHUB_TOKEN'))
+        .orNull
+
+    release {
+        github {
+            enabled = true
+            repoOwner = 'token-ledger'
+            name = 'token-ledger'
+            skipTag = true
+            skipRelease = true
+
+            if (githubToken) {
+                token = githubToken
+            }
+        }
+    }
+
+    signing {
+        pgp {
+            active = 'RELEASE'
+            armored = true
+
+            if (signingPublicKeyFile && signingSecretKeyFile) {
+                mode = 'FILE'
+                publicKey = signingPublicKeyFile
+                secretKey = signingSecretKeyFile
+            }
+
+            if (signingPassphrase) {
+                passphrase = signingPassphrase
+            }
+        }
+    }
+
+    deploy {
+        maven {
+            mavenCentral {
+                sonatype {
+                    active = 'RELEASE'
+                    url = 'https://central.sonatype.com/api/v1/publisher'
+                    namespace = 'cloud.token-ledger'
+                    stagingRepository('build/staging-deploy')
+
+                    if (centralUsername) {
+                        username = centralUsername
+                    }
+
+                    if (centralPassword) {
+                        password = centralPassword
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -43,11 +130,22 @@ subprojects {
 
     if (!(name in ['token-ledger-sample-app', 'external-consumer-fixture'])) {
         apply plugin: 'maven-publish'
+        apply plugin: 'signing'
 
         java {
             withSourcesJar()
             withJavadocJar()
         }
+
+        def signingKeyFile = providers.gradleProperty('signingKeyFile')
+            .orElse(providers.environmentVariable('SIGNING_KEY_FILE'))
+            .orNull
+        def signingKey = providers.gradleProperty('signingKey')
+            .orElse(providers.environmentVariable('SIGNING_KEY'))
+            .orNull
+        def signingPassword = providers.gradleProperty('signingPassword')
+            .orElse(providers.environmentVariable('SIGNING_PASSWORD'))
+            .orNull
 
         publishing {
             publications {
@@ -104,6 +202,11 @@ subprojects {
             repositories {
                 mavenLocal()
 
+                maven {
+                    name = 'staging'
+                    url = layout.buildDirectory.dir('staging-deploy')
+                }
+
                 def mavenRepoUrl = providers.gradleProperty('mavenRepoUrl').orNull
                 def mavenRepoUsername = providers.gradleProperty('mavenRepoUsername')
                     .orElse(providers.environmentVariable('MAVEN_REPO_USERNAME'))
@@ -123,6 +226,20 @@ subprojects {
                     }
                 }
             }
+        }
+
+        signing {
+            required {
+                !project.version.toString().endsWith('-SNAPSHOT')
+            }
+
+            if (signingKeyFile && signingPassword) {
+                useInMemoryPgpKeys(file(signingKeyFile).text, signingPassword)
+            } else if (signingKey && signingPassword) {
+                useInMemoryPgpKeys(signingKey, signingPassword)
+            }
+
+            sign publishing.publications.mavenJava
         }
     }
 }


### PR DESCRIPTION
## 변경 사항
- Gradle signing 및 projectVersion 릴리스 오버라이드 추가
- JReleaser 기반 Central Portal staging/deploy 설정 추가
- release signing 및 Central 배포 절차 문서화

## 검증
- ./gradlew publishToMavenLocal -PprojectVersion=0.0.1
- ./gradlew jreleaserConfig -PprojectVersion=0.0.1 --dryrun
