### PR TITLE
docs: 메이븐 센트럴 소비 예제와 검증 경로 정리

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Primary goal: users should eventually add one dependency, `token-ledger-starter`
 | `token-ledger-autoconfigure` | Basic implementation complete | Bean registration, property binding, pricing/budget wiring, and ChatClient customizer implemented |
 | `token-ledger-starter` | Basic implementation complete | Thin final user entrypoint that brings runtime modules together |
 | `token-ledger-sample-app` | Basic E2E complete | Direct ledger metrics, budget, and fake Spring AI advisor E2E implemented |
-| `external-consumer-fixture` | Basic implementation complete | Verification module that consumes the published starter from `mavenLocal` |
+| `external-consumer-fixture` | Basic implementation complete | Verification module that consumes the published starter from Maven Central by default and can target snapshots explicitly |
 
 ## Current Work Focus
 
@@ -46,7 +46,7 @@ The current MVP workstream is packaging and external consumer validation.
 MVP tasks:
 
 - Keep sample app dependent on `project(':token-ledger-starter')`.
-- Keep local Maven publishing and the external consumer fixture healthy as the default artifact verification path.
+- Keep local Maven publishing healthy for snapshot verification and keep the external consumer fixture healthy as the default Maven Central release verification path.
 - Validate GitHub Packages snapshot publishing before public release.
 - Keep published POM metadata aligned with Maven Central promotion requirements.
 - Keep Gradle signing and release property wiring ready for Central release work.
@@ -202,12 +202,12 @@ MVP publishing should proceed in this order:
 5. Verify the consumer can use only `implementation 'cloud.token-ledger:token-ledger-starter:0.0.1-SNAPSHOT'`.
 6. Publish snapshots to GitHub Packages.
 7. Document consumer credentials and CI publish flow before public release.
-8. Add signing and staging automation before Maven Central promotion.
+8. Verify Maven Central release consumption with `mavenCentral()` only.
 
 ## Roadmap
 
-1. GitHub Packages snapshot publishing flow and CI credentials setup.
-2. Maven Central staging and release execution flow hardening.
+1. Maven Central release consumption regression coverage.
+2. GitHub Packages snapshot publishing flow and CI credentials setup.
 3. Real provider Spring AI smoke verification behind an opt-in profile.
 4. Micrometer options object for autoconfigure integration.
 5. Budget policy expansion.
@@ -218,7 +218,7 @@ MVP publishing should proceed in this order:
 - `core.internal` implementation classes are package-private by design. Cross-module construction should continue through public factory/configuration APIs.
 - Micrometer publisher filters tags, but the configuration is still constructor-level and should be wrapped in an options object before autoconfigure integration.
 - Sample app E2E uses a fake Spring AI `ChatModel`; real provider API behavior is not yet verified.
-- Public remote repository consumption is not yet verified outside local Maven and GitHub Packages snapshot flow.
+- Maven Central release consumption is now verified manually, but automated regression coverage is still thin.
 
 ## Verification
 
@@ -243,8 +243,15 @@ curl http://localhost:8080/actuator/prometheus
 Verify the published starter from the external consumer module:
 
 ```bash
-./gradlew publishToMavenLocal
 ./gradlew :external-consumer-fixture:bootRun -PusePublishedStarter=true
+curl http://localhost:8081/test/token-ledger/published
+```
+
+Verify the snapshot path explicitly:
+
+```bash
+./gradlew publishToMavenLocal
+./gradlew :external-consumer-fixture:bootRun -PusePublishedStarter=true -PpublishedStarterVersion=0.0.1-SNAPSHOT
 curl http://localhost:8081/test/token-ledger/published
 ```
 
@@ -279,6 +286,7 @@ Stage and deploy a Central release:
 - Chose GitHub Packages as the first remote snapshot repository target and documented the publish command in `README.md`.
 - Added GitHub Packages consumer examples and expanded published POM metadata for later Maven Central promotion.
 - Switched `external-consumer-fixture` to use `project(':token-ledger-starter')` by default and require `-PusePublishedStarter=true` for published artifact verification so CI builds do not fail before publish.
+- Promoted `cloud.token-ledger:token-ledger-starter:0.0.1` to Maven Central and switched `external-consumer-fixture` to use the Central release by default when published artifact verification is enabled.
 - Added Gradle `signing` integration and `projectVersion` override support so release builds can be produced with local GPG material before Central Portal upload wiring is finalized.
 - Prefer `signingKeyFile` over inline `signingKey` for local release signing because multiline armored keys are less error-prone when loaded from a file.
 - Added JReleaser Gradle integration targeting the Central Publisher Portal with `build/staging-deploy` staging repositories and `cloud.token-ledger` namespace wiring.

--- a/README.md
+++ b/README.md
@@ -127,19 +127,63 @@ curl http://localhost:8080/actuator/prometheus
 
 ## Maven Publishing
 
+### Maven Central Release
+
+Published release coordinates:
+
+```text
+cloud.token-ledger:token-ledger-starter:0.0.1
+```
+
+Consume the release from Maven Central like a normal dependency:
+
+```gradle
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation "cloud.token-ledger:token-ledger-starter:0.0.1"
+}
+```
+
+Run the repository-managed external consumer module against the Central release:
+
+```bash
+./gradlew :external-consumer-fixture:bootRun -PusePublishedStarter=true
+```
+
+Verify that the external app booted from the published artifact path:
+
+```bash
+curl http://localhost:8081/test/token-ledger/published
+```
+
+Prepare a signed release build locally:
+
+```bash
+./gradlew publishToMavenLocal -PprojectVersion=0.0.1
+```
+
+Release-to-Central flow:
+
+```bash
+./gradlew publishAllPublicationsToStagingRepository -PprojectVersion=0.0.1
+./gradlew jreleaserConfig -PprojectVersion=0.0.1
+./gradlew jreleaserDeploy -PprojectVersion=0.0.1
+```
+
+The repository now supports release-friendly version overrides with `-PprojectVersion=0.0.1`, signs published artifacts automatically when the signing key file properties are present, stages release artifacts into `build/staging-deploy`, and wires JReleaser to the Central Publisher Portal.
+
+### Snapshot Publishing
+
 Publish all library modules to your local Maven repository:
 
 ```bash
 ./gradlew publishToMavenLocal
 ```
 
-Prepare a release build with signing enabled:
-
-```bash
-./gradlew publishToMavenLocal -PprojectVersion=0.0.1
-```
-
-Published starter coordinates:
+Published snapshot coordinates:
 
 ```text
 cloud.token-ledger:token-ledger-starter:0.0.1-SNAPSHOT
@@ -148,7 +192,9 @@ cloud.token-ledger:token-ledger-starter:0.0.1-SNAPSHOT
 Run the external consumer module against the published starter:
 
 ```bash
-./gradlew publishToMavenLocal :external-consumer-fixture:bootRun -PusePublishedStarter=true
+./gradlew publishToMavenLocal :external-consumer-fixture:bootRun \
+  -PusePublishedStarter=true \
+  -PpublishedStarterVersion=0.0.1-SNAPSHOT
 ```
 
 Verify that the external app booted from the published artifact path:
@@ -192,8 +238,6 @@ gpr.user=your-github-id
 gpr.key=ghp_xxx
 ```
 
-For Maven Central promotion later, the published POM already includes license, SCM, issue tracker, CI, organization, developer, and inception year metadata. Signing and staging flow are still pending.
-
 Example `~/.gradle/gradle.properties` for release signing and Central Portal credentials:
 
 ```properties
@@ -214,16 +258,6 @@ chmod 600 ~/.gradle/token-ledger-public.asc
 chmod 600 ~/.gradle/token-ledger-signing.asc
 ```
 
-Release-to-Central flow:
-
-```bash
-./gradlew publishAllPublicationsToStagingRepository -PprojectVersion=0.0.1
-./gradlew jreleaserConfig -PprojectVersion=0.0.1
-./gradlew jreleaserDeploy -PprojectVersion=0.0.1
-```
-
-The repository now supports release-friendly version overrides with `-PprojectVersion=0.0.1`, signs published artifacts automatically when the signing key file properties are present, stages release artifacts into `build/staging-deploy`, and wires JReleaser to the Central Publisher Portal.
-
 ## Current Status
 
 The starter and autoconfigure path is implemented at a basic level:
@@ -235,7 +269,7 @@ The starter and autoconfigure path is implemented at a basic level:
 - The sample app confirms starter classpath, bean registration, direct ledger recording, Spring AI `ChatClient` advisor flow with a fake model, budget behavior, token-ledger metrics, and Prometheus actuator exposure.
 - Library modules publish through `maven-publish`.
 - `external-consumer-fixture` uses a project dependency by default so the main CI build stays green.
-- Published artifact verification is enabled explicitly with `-PusePublishedStarter=true`.
+- Published artifact verification is enabled explicitly with `-PusePublishedStarter=true`, with release `0.0.1` as the default published coordinate and `-PpublishedStarterVersion=0.0.1-SNAPSHOT` available for snapshot checks.
 
 Remaining MVP work:
 

--- a/external-consumer-fixture/build.gradle
+++ b/external-consumer-fixture/build.gradle
@@ -7,6 +7,10 @@ plugins {
 group = 'io.tokenledger.fixture'
 version = '0.0.1-SNAPSHOT'
 
+def usePublishedStarter = providers.gradleProperty('usePublishedStarter').map(Boolean.&parseBoolean).getOrElse(false)
+def publishedStarterVersion = providers.gradleProperty('publishedStarterVersion').getOrElse('0.0.1')
+def useSnapshotStarter = publishedStarterVersion.endsWith('-SNAPSHOT')
+
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(25)
@@ -14,12 +18,14 @@ java {
 }
 
 repositories {
-    mavenLocal()
-    maven {
-        url = uri("https://maven.pkg.github.com/token-ledger/token-ledger")
-        credentials {
-            username = findProperty("gpr.user") ?: System.getenv("GITHUB_ACTOR")
-            password = findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
+    if (!usePublishedStarter || useSnapshotStarter) {
+        mavenLocal()
+        maven {
+            url = uri("https://maven.pkg.github.com/token-ledger/token-ledger")
+            credentials {
+                username = findProperty("gpr.user") ?: System.getenv("GITHUB_ACTOR")
+                password = findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
+            }
         }
     }
     mavenCentral()
@@ -33,8 +39,8 @@ dependencyManagement {
 }
 
 dependencies {
-    if (providers.gradleProperty('usePublishedStarter').map(Boolean.&parseBoolean).getOrElse(false)) {
-        implementation 'cloud.token-ledger:token-ledger-starter:0.0.1-SNAPSHOT'
+    if (usePublishedStarter) {
+        implementation "cloud.token-ledger:token-ledger-starter:${publishedStarterVersion}"
     } else {
         implementation project(':token-ledger-starter')
     }


### PR DESCRIPTION
## 변경 사항
- README를 Maven Central release 소비 중심으로 재정리
- GitHub Packages snapshot 경로와 Central release 경로 분리
- external-consumer-fixture가 published artifact 검증 시 release 0.0.1을 기본으로 사용하도록 조정
- snapshot 검증은 publishedStarterVersion으로 명시적으로만 사용하도록 정리

## 검증
- ./gradlew :external-consumer-fixture:dependencies --configuration runtimeClasspath -PusePublishedStarter=true
- ./gradlew :external-consumer-fixture:bootRun -PusePublishedStarter=true
- curl http://localhost:8081/test/token-ledger/published